### PR TITLE
SBT Bintray plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,42 @@
-# InteliJ IDEA
-.idea
+logs
+target
+tmp
+.history
+dist
+/out
+/RUNNING_PID
+/.ivy*
 
-# SBT
-/target/
-/project/target
-/project/project/target
+# sbt specific
+/.sbt
+.cache/
+.history/
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/project
+project/target
+/.activator
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+#Eclipse specific
+.classpath
+.project
+.cache
+.settings/
+
+#IntelliJ IDEA specific
+.idea/
+/.idea_modules
+/.idea
+/*.iml
+
+#Proguard
+proguard-sbt.txt

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 License
 ======
 
-Copyright (C) 2012 47 Degrees, LLC http://47deg.com hello@47deg.com
+Copyright (C) 2015 47 Degrees, LLC http://47deg.com hello@47deg.com
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 resolvers ++= Seq(
     ...
     Resolver.mavenLocal,
-    "47Deg Bintray Repo" at "http://dl.bintray.com/47deg/maven/"
+    "jcenter" at "http://jcenter.bintray.com"
 )
 
 libraryDependencies ++= Seq(

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 resolvers ++= Seq(
     ...
     Resolver.mavenLocal,
-    "jcenter" at "http://jcenter.bintray.com"
+    "47Deg Bintray Repo" at "http://dl.bintray.com/47deg/maven/"
 )
 
 libraryDependencies ++= Seq(

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Usage
 resolvers ++= Seq(
     ...
     Resolver.mavenLocal,
-    "47deg Public" at "http://clinker.47deg.com/nexus/content/groups/public"
+    "jcenter" at "http://jcenter.bintray.com"
 )
 
 libraryDependencies ++= Seq(
-  aar("com.fortysevendeg" %% "macroid-extras" % "<Version | 0.1-SNAPSHOT>")
+  aar("com.fortysevendeg" %% "macroid-extras" % "<Version | 0.2-M1>")
 
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,19 +7,11 @@ platformTarget in Android := Versions.androidPlatformV
 
 name := "macroid-extras"
 
-organization := "com.fortysevendeg"
-
-organizationName := "47 Degrees"
-
-organizationHomepage := Some(new URL("http://47deg.com"))
-
 version := Versions.appV
 
 scalaVersion := Versions.scalaV
 
 scalacOptions ++= Seq("-feature", "-deprecation")
-
-credentials += Credentials(new File(Path.userHome.absolutePath + "/.ivy2/.credentials"))
 
 resolvers ++= Seq(
   Resolver.mavenLocal,
@@ -33,8 +25,7 @@ resolvers ++= Seq(
   "jcenter" at "http://jcenter.bintray.com",
   Resolver.url(
     "bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
-  "47deg Public" at "http://clinker.47deg.com/nexus/content/groups/public"
+    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 )
 
 libraryDependencies ++= Seq(
@@ -43,27 +34,4 @@ libraryDependencies ++= Seq(
   aar(androidCardView),
   aar(androidRecyclerview))
 
-publishMavenStyle := false
-
-seq(bintrayPublishSettings:_*)
-
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
-
-startYear := Some(2015)
-
-description := "47 Degrees Macroid Extras"
-
-homepage := Some(url("http://47deg.com"))
-
-scmInfo := Some(ScmInfo(url("https://github.com/47deg/macroid-extras"), "https://github.com/47deg/macroid-extras.git"))
-
-pomExtra :=
-    <developers>
-      <developer>
-        <name>47 Degrees (twitter: @47deg)</name>
-        <email>hello@47deg.com</email>
-      </developer>
-      <developer>
-        <name>47 Degrees</name>
-      </developer>
-    </developers>

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,9 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.defaultLocal,
   "jcenter" at "http://jcenter.bintray.com",
+  Resolver.url(
+    "bintray-sbt-plugin-releases",
+    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
   "47deg Public" at "http://clinker.47deg.com/nexus/content/groups/public"
 )
 
@@ -40,15 +43,11 @@ libraryDependencies ++= Seq(
   aar(androidCardView),
   aar(androidRecyclerview))
 
-publishMavenStyle := true
+publishMavenStyle := false
 
-publishTo <<= version {
-  v: String =>
-    if (v.trim.endsWith("SNAPSHOT"))
-      Some("47deg Public Snapshot Repository" at "http://clinker.47deg.com/nexus/content/repositories/snapshots")
-    else
-      Some("47deg Public Release Repository" at "http://clinker.47deg.com/nexus/content/repositories/releases")
-}
+seq(bintrayPublishSettings:_*)
+
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 startYear := Some(2015)
 

--- a/project.properties
+++ b/project.properties
@@ -1,2 +1,3 @@
 # Project target.
-target=android-21
+target=Google Inc.:Google APIs:21
+android.library=true

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
 
-  val appV = "0.1-SNAPSHOT"
+  val appV = "0.1"
   val scalaV = "2.11.4"
   val androidPlatformV = "android-21"
   val androidV = "21.0.0"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,6 +1,6 @@
 object Versions {
 
-  val appV = "0.1"
+  val appV = "0.2-M1"
   val scalaV = "2.11.4"
   val androidPlatformV = "android-21"
   val androidV = "21.0.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
-addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.13")
+addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.17")
+
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.0")

--- a/publish.sbt
+++ b/publish.sbt
@@ -8,6 +8,8 @@ publishMavenStyle := true
 
 seq(bintrayPublishSettings:_*)
 
+bintray.Keys.bintrayOrganization in bintray.Keys.bintray := Some("47deg")
+
 startYear := Some(2015)
 
 description := "47 Degrees Macroid Extras"

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,0 +1,28 @@
+organization := "com.fortysevendeg"
+
+organizationName := "47 Degrees"
+
+organizationHomepage := Some(new URL("http://47deg.com"))
+
+publishMavenStyle := true
+
+seq(bintrayPublishSettings:_*)
+
+startYear := Some(2015)
+
+description := "47 Degrees Macroid Extras"
+
+homepage := Some(url("http://47deg.com"))
+
+scmInfo := Some(ScmInfo(url("https://github.com/47deg/macroid-extras"), "https://github.com/47deg/macroid-extras.git"))
+
+pomExtra :=
+    <developers>
+      <developer>
+        <name>47 Degrees (twitter: @47deg)</name>
+        <email>hello@47deg.com</email>
+      </developer>
+      <developer>
+        <name>47 Degrees</name>
+      </developer>
+    </developers>


### PR DESCRIPTION
This PR adds the needed sbt configuration to be able to publish the artifact in Bintray. The app version has been upgraded to `0.2-M1` (for development purposes) and we've released the `0.1` to be used by the apps in production. For now, both versions are released from the same code.

Also, the build.sbt file has been splitted.

I've setup the 47Deg Bintray account to deploy snapshot build artifacts on the OSS Artifactory at https://oss.jfrog.org

This allows you to have your project’s builds snapshots deployed to https://oss.jfrog.org and to release and publish them to Bintray in one click.

Please, @raulraja  @javipacheco  could you review? Thanks.