### PR TITLE
EditTextTweaks converted to object

### DIFF
--- a/src/main/scala/com/fortysevendeg/macroid/extras/EditTextTweaks.scala
+++ b/src/main/scala/com/fortysevendeg/macroid/extras/EditTextTweaks.scala
@@ -24,7 +24,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import macroid.{ ContextWrapper, Tweak }
 
-class EditTextTweaks {
+object EditTextTweaks {
   type W = EditText
 
   def etAddTextChangedListener(onChanged: (String, Int, Int, Int) ⇒ Unit) = Tweak[W] { view ⇒


### PR DESCRIPTION
This PR resolves a bug in `EditTextTweaks`. We must use `object` instead of `class`

@fedefernandez can you please review? thanks!